### PR TITLE
add mountainsort4 image

### DIFF
--- a/kilosort2/build.sh
+++ b/kilosort2/build.sh
@@ -2,4 +2,4 @@
 
 # usually the tag would be the version of the sorter
 # but in this case since 2 is already in the name, maybe the tag should be 0.1.x
-docker build -t spikeinterface/kilosort2:0.1.0 .
+docker build -t spikeinterface/kilosort2-base:0.1.0 .

--- a/kilosort2/push.sh
+++ b/kilosort2/push.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker push spikeinterface/kilosort2:0.1.0
+docker push spikeinterface/kilosort2-base:0.1.0

--- a/mountainsort4/Dockerfile
+++ b/mountainsort4/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.8
+
+RUN pip install numpy
+
+# Install MountainSort4
+RUN pip install mountainsort4==1.0.0

--- a/mountainsort4/build.sh
+++ b/mountainsort4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t spikeinterface/mountainsort4:1.0.0 .

--- a/mountainsort4/build.sh
+++ b/mountainsort4/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/mountainsort4:1.0.0 .
+docker build -t spikeinterface/mountainsort4-base:1.0.0 .

--- a/mountainsort4/push.sh
+++ b/mountainsort4/push.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker push spikeinterface/mountainsort4:1.0.0

--- a/mountainsort4/push.sh
+++ b/mountainsort4/push.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker push spikeinterface/mountainsort4:1.0.0
+docker push spikeinterface/mountainsort4-base:1.0.0

--- a/spykingcircus/build.sh
+++ b/spykingcircus/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/spyking-circus:1.0.7 .
+docker build -t spikeinterface/spyking-circus-base:1.0.7 .

--- a/spykingcircus/push.sh
+++ b/spykingcircus/push.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker push spikeinterface/spyking-circus:1.0.7
+docker push spikeinterface/spyking-circus-base:1.0.7


### PR DESCRIPTION
I made a cleaned-up package of ml_ms4alg called [mountainsort4](https://github.com/magland/mountainsort4) which is now on pypi. It's the same algorithm, just simplified packaging and some cleanup of the source code.

This docker image simply pip installs that package.

Here's the spikeforest image, wrapper, and example:
https://github.com/flatironinstitute/spikeforest/blob/main/spikeforest/sorters/mountainsort4/docker/Dockerfile
https://github.com/flatironinstitute/spikeforest/blob/main/spikeforest/sorters/mountainsort4/mountainsort4_wrapper1.py
https://github.com/flatironinstitute/spikeforest/blob/main/devel/sorting/test_mountainsort4.py