### PR TITLE
Updated YASS container

### DIFF
--- a/yass/Dockerfile
+++ b/yass/Dockerfile
@@ -7,39 +7,70 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 # setup time zone for tz
 ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-# Install python3.7
-RUN apt-get update
-RUN apt-get install -y software-properties-common wget
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get install -y python3.7 python3.7-dev python3.7-tk python3-pip python3.7-venv git ffmpeg libgtk-3-dev
-
-# Install Python dependencies
-ARG PYTHON=python3.7
 ENV LANG C.UTF-8
-ENV CONDA_PATH=/opt/anaconda3
-ENV ENVIRONMENT_NAME=main
-SHELL ["/bin/bash", "-c"]
 
-# Download and install Anaconda.
-ENV LATEST_CONDA_SCRIPT "Anaconda3-5.3.1-Linux-x86_64.sh"
-ENV PATH="/root/anaconda2/bin:${PATH}"
+RUN apt-get update
+RUN apt-get install -y software-properties-common wget git
 
-RUN wget https://repo.continuum.io/archive/$LATEST_CONDA_SCRIPT
+# Install conda from: https://towardsdatascience.com/conda-pip-and-docker-ftw-d64fe638dc45
+SHELL [ "/bin/bash", "--login", "-c" ]
 
-RUN bash $LATEST_CONDA_SCRIPT -b -p /home/anaconda3 \
-	&& echo "export PATH=/home/anaconda/bin:$PATH" >> ~/.bashrc \
-	&& /bin/bash -c "source /root/.bashrc"
+# Create a non-root user
+ARG username=si
+ARG uid=1000
+ARG gid=100
+ENV USER $username
+ENV UID $uid
+ENV GID $gid
+ENV HOME /home/$USER
+RUN adduser --disabled-password \
+    --gecos "Non-root user" \
+    --uid $UID \
+    --gid $GID \
+    --home $HOME \
+    $USER
 
-ENV PATH /home/anaconda3/bin:$PATH
+COPY entrypoint.sh /usr/local/bin/
+RUN chown $UID:$GID /usr/local/bin/entrypoint.sh && \
+    chmod u+x /usr/local/bin/entrypoint.sh
 
+
+USER $USER
+# install miniconda
+ENV MINICONDA_VERSION 4.8.2
+ENV CONDA_DIR $HOME/miniconda3
+#https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh
+ENV LATEST_CONDA_SCRIPT "Miniconda3-py37_$MINICONDA_VERSION-Linux-x86_64.sh"
+
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/miniconda.sh && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p $CONDA_DIR && \
+    rm ~/miniconda.sh
+
+# make non-activate conda commands available
+ENV PATH=$CONDA_DIR/bin:$PATH
+# make conda activate command available from /bin/bash --login shells
+RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.profile
+# make conda activate command available from /bin/bash --interative shells
+RUN conda init bash
+
+# create a project directory inside user home
+ENV PROJECT_DIR $HOME/app
+RUN mkdir $PROJECT_DIR
+WORKDIR $PROJECT_DIR
+
+ENV CONDA_ENV_NAME yass
+RUN conda create -n $CONDA_ENV_NAME
+RUN conda activate $CONDA_ENV_NAME 
+
+
+# install yass
 RUN conda install pytorch==1.2
-#RUN rm $LATEST_CONDA_SCRIPT
-#conda install pytorch==1.2.0 torchvision==0.4.0 cudatoolkit=10.0 -c pytorch
-
+#RUN git clone --depth 1 --branch v2.0 https://github.com/paninski-lab/yass \
 RUN git clone https://github.com/paninski-lab/yass \
    && cd yass \
+   && git checkout d9c9e2c52287afeb3256bdfde749f75f5083fd5d \
    && pip --no-cache-dir install -e . \
    && cd src/gpu_bspline_interp \
    && python setup.py install --force \
@@ -50,5 +81,5 @@ RUN git clone https://github.com/paninski-lab/yass \
    && pip install .
 
 RUN pip install scipy==1.2.0
-#cd yass/samples/10chan
-#yass sort config.yaml
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/yass/build.sh
+++ b/yass/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t spikeinterface/yass-base:2.0.0 .

--- a/yass/entrypoint.sh
+++ b/yass/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash --login
+set -e
+conda activate $CONDA_ENV_NAME 
+exec "$@"

--- a/yass/push.sh
+++ b/yass/push.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker push spikeinterface/yass-base:2.0.0


### PR DESCRIPTION
### Updates

- Updated and tested YASS docker
- Added build.sh and push.sh
- Fixes entrypoint for conda environment

### Notes
- [this commit](https://github.com/paninski-lab/yass/commit/d9c9e2c52287afeb3256bdfde749f75f5083fd5d) is checked out because of an [issue with master](https://github.com/paninski-lab/yass/issues/342)
- In order to run the container, the command needs to be: `docker run --gpus all -it --entrypoint /bin/bash yass:2.0.0`
  - the `--gpus all` ensures the GPU(s) are used correctly in the container
  - `--entrypoint /bin/bash` is needed to run the entrypoint script, which activates the right environment
  
@yger can you test this? @samuelgarcia for SI docker runs, I suggest we add a class variables `docker_requires_gpu` and `docker_requires_entrypoint` flags to modify the docker commands. Should be straightforward (https://docker-py.readthedocs.io/en/stable/containers.html)