### PR TITLE
downgrade pip version to avoid dependency issues during installations

### DIFF
--- a/mountainsort4/Dockerfile
+++ b/mountainsort4/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.8
 
+# downgrade pip version to avoid dependency issues during installations
+RUN pip install --no-input pip==21.2.4
+
 RUN pip install numpy
 
 # Install MountainSort4

--- a/spykingcircus/Dockerfile
+++ b/spykingcircus/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.8
 
+# downgrade pip version to avoid dependency issues during installations
+RUN pip install --no-input pip==21.2.4
+
 RUN pip install numpy
 
 # Install SpyKING CIRCUS

--- a/tridesclous/Dockerfile
+++ b/tridesclous/Dockerfile
@@ -3,12 +3,19 @@ FROM python:3.8
 # downgrade pip version to avoid dependency issues during installations
 RUN pip install --no-input pip==21.2.4
 
-RUN pip install numpy
+
 
 # Install prerequisites
 RUN apt-get update && apt-get install -y libgl1-mesa-glx
+
+# need to force some version
+RUN pip install numpy==1.20
+RUN pip install numba
+RUN pip install git+https://github.com/scikit-learn-contrib/hdbscan.git
+
+
 RUN pip install Cython
-RUN pip install scipy numpy pandas scikit-learn matplotlib seaborn tqdm openpyxl quantities neo numba hdbscan
+RUN pip install scipy pandas scikit-learn matplotlib seaborn tqdm openpyxl quantities neo
 RUN pip install h5py
 RUN pip install loky
 

--- a/tridesclous/Dockerfile
+++ b/tridesclous/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.8
 
+# downgrade pip version to avoid dependency issues during installations
+RUN pip install --no-input pip==21.2.4
+
 RUN pip install numpy
 
 # Install prerequisites


### PR DESCRIPTION
related to https://github.com/SpikeInterface/spikeinterface/pull/440

force pip version here instead of in spikeinterface code.
