### PR TITLE
Pykilosort

### DIFF
--- a/pykilosort/Dockerfile
+++ b/pykilosort/Dockerfile
@@ -1,0 +1,56 @@
+FROM nvidia/cuda:10.0-base-ubuntu18.04 
+
+LABEL maintainer="Vincent Prevosto <prevosto@mit.edu>"
+
+# USER root
+# # Ubuntu package installs
+RUN apt update 
+RUN apt install -y --no-install-recommends \
+    libfftw3-dev \
+    git \
+    wget && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Make bash the default shell, for compatibility with conda
+# SHELL [ "/bin/bash", "--login",  "-c" ]
+
+# install miniconda
+ENV MINICONDA_VERSION 4.12.0
+ENV CONDA_DIR /home/miniconda3
+ENV LATEST_CONDA_SCRIPT "Miniconda3-py38_$MINICONDA_VERSION-Linux-x86_64.sh"
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/miniconda.sh && \
+    bash ~/miniconda.sh -b -p $CONDA_DIR && \
+    rm ~/miniconda.sh
+# RUN echo 'export PATH="~/miniconda/bin:$PATH"' >> ~/.bashrc 
+ENV PATH=$CONDA_DIR/bin:$PATH
+RUN conda update conda
+
+# chmod +x ~/miniconda.sh && \
+# ~/miniconda.sh -b -p $CONDA_DIR && \
+# rm ~/miniconda.sh
+
+# # make non-activate conda commands available
+# ENV PATH=$CONDA_DIR/bin:$PATH
+# # make conda activate command available from /bin/bash --login shells
+# RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile 
+# # make conda activate command available from /bin/bash --interactive shells
+# RUN conda init bash
+
+# Install IBL port of pykilosort
+RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
+WORKDIR /src/pykilosort
+
+# Create environment
+RUN conda env create -f pyks2.yml
+
+# Install pykilosort
+SHELL ["conda","run","-n","pyks2","/bin/bash","-c"]
+# RUN conda install --quiet --yes ipykernel && \
+#     python -m ipykernel install --user --name pyks2 --display-name "pyKilosort" && \
+RUN conda develop .
+
+
+
+

--- a/pykilosort/Dockerfile
+++ b/pykilosort/Dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:10.0-base-ubuntu18.04
 LABEL maintainer="Vincent Prevosto <prevosto@mit.edu>"
 
 # USER root
-# # Ubuntu package installs
+# Ubuntu package installs
 RUN apt update 
 RUN apt install -y --no-install-recommends \
     libfftw3-dev \
@@ -24,6 +24,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/m
 ENV PATH=$CONDA_DIR/bin:$PATH
 RUN conda update conda && \
     conda install conda-build
+
+# make conda activate command available from /bin/bash --login shells
+RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile 
+# make conda activate command available from /bin/bash --interactive shells
+RUN conda init bash
 
 # Install IBL port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort

--- a/pykilosort/Dockerfile
+++ b/pykilosort/Dockerfile
@@ -12,9 +12,6 @@ RUN apt install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Make bash the default shell, for compatibility with conda
-# SHELL [ "/bin/bash", "--login",  "-c" ]
-
 # install miniconda
 ENV MINICONDA_VERSION 4.12.0
 ENV CONDA_DIR /home/miniconda3
@@ -25,18 +22,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/m
     rm ~/miniconda.sh
 # RUN echo 'export PATH="~/miniconda/bin:$PATH"' >> ~/.bashrc 
 ENV PATH=$CONDA_DIR/bin:$PATH
-RUN conda update conda
-
-# chmod +x ~/miniconda.sh && \
-# ~/miniconda.sh -b -p $CONDA_DIR && \
-# rm ~/miniconda.sh
-
-# # make non-activate conda commands available
-# ENV PATH=$CONDA_DIR/bin:$PATH
-# # make conda activate command available from /bin/bash --login shells
-# RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile 
-# # make conda activate command available from /bin/bash --interactive shells
-# RUN conda init bash
+RUN conda update conda && \
+    conda install conda-build
 
 # Install IBL port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort

--- a/pykilosort/README.md
+++ b/pykilosort/README.md
@@ -1,5 +1,39 @@
 ### Build this image
+Build default image: 
+docker build -t pykilosort:latest -f dockerfiles/Dockerfile .
 
+Build image with additional testing components: 
+docker build -t pykilosort:test -f dockerfiles/Dockerfile.testing context
 
 ### Run container
-docker run --rm --gpus all pykilosort
+docker run --rm -it -v <host-data-folder>:<docker-data-folder> --gpus all pykilosort:latest
+flags:
+--rm: removes container once it's stopped
+-it: for interactive session
+-v: mounted volumes (directories)
+--gpus: enables GPU use within container 
+
+### Test
+Download Neuropixel 1.0 data to your data directory: https://catalystneuro.github.io/spike-sorting-hackathon/datasets/datasets.html#allen-institute-example
+(see also https://github.com/int-brain-lab/pykilosort/tree/ibl_prod/examples, although apparently not up to date)
+
+$docker run --rm -it -v /my/dir/to/data:/data --gpus all pykilosort
+#conda activate pyks2
+#cd /data
+    --- alternatively, get data from kachery (if installed and configured) ---
+    ```
+    wget https://catalystneuro.github.io/spike-sorting-hackathon/datasets/examples/example_allen_NP1.py
+    python example_allen_NP1.py
+    ```
+
+The either run tests in ipython console, or run example from /home/test_file directory (if using `.testing` image), after editing directory paths
+#ipython
+```
+from pathlib import Path
+from pykilosort import run, add_default_handler, np1_probe, np2_probe
+
+data_path = Path('/data/Allen_Institute_NP1/continuous_1min.bin')
+dir_path = Path('/data/Allen_Institute_NP1/pyKS_output')
+add_default_handler(level='INFO') # print output as the algorithm runs
+run(data_path, dir_path=dir_path, probe=np1_probe())
+```

--- a/pykilosort/README.md
+++ b/pykilosort/README.md
@@ -35,5 +35,5 @@ from pykilosort import run, add_default_handler, np1_probe, np2_probe
 data_path = Path('/data/Allen_Institute_NP1/continuous_1min.bin')
 dir_path = Path('/data/Allen_Institute_NP1/pyKS_output')
 add_default_handler(level='INFO') # print output as the algorithm runs
-run(data_path, dir_path=dir_path, probe=np1_probe())
+run(data_path, dir_path=dir_path, probe=np1_probe(sync_channel=False))
 ```

--- a/pykilosort/README.md
+++ b/pykilosort/README.md
@@ -33,7 +33,7 @@ from pathlib import Path
 from pykilosort import run, add_default_handler, np1_probe, np2_probe
 
 data_path = Path('/data/Allen_Institute_NP1/continuous_1min.bin')
-dir_path = Path('/data/Allen_Institute_NP1/pyKS_output')
+dir_path = Path('/data/Allen_Institute_NP1/output')
 add_default_handler(level='INFO') # print output as the algorithm runs
 run(data_path, dir_path=dir_path, probe=np1_probe(sync_channel=False))
 ```

--- a/pykilosort/README.md
+++ b/pykilosort/README.md
@@ -1,0 +1,5 @@
+### Build this image
+
+
+### Run container
+docker run --rm --gpus all pykilosort

--- a/pykilosort/build.sh
+++ b/pykilosort/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/pykilosort:0.1.0 .
+docker build -t spikeinterface/pykilosort:latest -t spikeinterface/pykilosort:0.1.0 .

--- a/pykilosort/build.sh
+++ b/pykilosort/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t spikeinterface/pykilosort:0.1.0 .

--- a/pykilosort/build.sh
+++ b/pykilosort/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/pykilosort:latest -t spikeinterface/pykilosort:0.1.0 .
+docker build -t spikeinterface/pykilosort:latest -t spikeinterface/pykilosort:0.1.0 -f dockerfiles/Dockerfile .

--- a/pykilosort/context/packages/testing_requirements.txt
+++ b/pykilosort/context/packages/testing_requirements.txt
@@ -1,0 +1,5 @@
+spikeinterface[full]
+dandi
+kachery
+kachery-cloud
+git+https://github.com/flatironinstitute/spikeforest2.git@master

--- a/pykilosort/context/test_files/example_general_users.py
+++ b/pykilosort/context/test_files/example_general_users.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from pykilosort import run, add_default_handler, np1_probe, np2_probe
+
+# Run standard ks2.5 algorithm for a np1 probe
+data_path = Path('path/to/data/data.bin')
+dir_path = Path('path/to/output/folder') # by default uses the same folder as the dataset
+add_default_handler(level='INFO') # print output as the algorithm runs
+run(data_path, dir_path=dir_path, probe=np1_probe())
+
+# Run chronic recordings for a np2 probe
+# For now this still uses ks2.5 clustering, chronic clustering algorithm coming soon!
+data_paths = [
+    Path('path/to/first/dataset/dataset.bin'),
+    Path('path/to/second/dataset/dataset.bin'),
+    Path('path/to/third/dataset/dataset.bin'),
+]
+dir_path = Path('path/to/output/folder') # by default uses the same folder as the first dataset
+add_default_handler(level='INFO')
+run(data_paths, dir_path=dir_path, probe=np2_probe(), low_memory=True)

--- a/pykilosort/dockerfiles/Dockerfile
+++ b/pykilosort/dockerfiles/Dockerfile
@@ -20,7 +20,6 @@ ENV LATEST_CONDA_SCRIPT "Miniconda3-py38_$MINICONDA_VERSION-Linux-x86_64.sh"
 RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/miniconda.sh && \
     bash ~/miniconda.sh -b -p $CONDA_DIR && \
     rm ~/miniconda.sh
-# RUN echo 'export PATH="/home/miniconda3/bin:$PATH"' >> ~/.bashrc 
 ENV PATH=$CONDA_DIR/bin:$PATH
 RUN conda update conda && \
     conda install conda-build
@@ -33,6 +32,9 @@ RUN conda init bash
 # Install python port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
 WORKDIR /src/pykilosort
+# Switch to MouseLand/develop branch - may revert to kushbanga/drift_test_stable in the future
+RUN git remote add MouseLand https://github.com/MouseLand/pykilosort.git && \
+    git fetch MouseLand && git checkout MouseLand/develop && git checkout -b develop
 
 # Create environment
 RUN conda env create -f pyks2.yml
@@ -42,3 +44,5 @@ SHELL ["conda","run","-n","pyks2","/bin/bash","-c"]
 RUN conda install --quiet --yes ipykernel && \
     python -m ipykernel install --user --name pyks2 --display-name "pyKilosort" && \
     conda develop .   
+
+WORKDIR /

--- a/pykilosort/dockerfiles/Dockerfile
+++ b/pykilosort/dockerfiles/Dockerfile
@@ -4,8 +4,8 @@ LABEL maintainer="Vincent Prevosto <prevosto@mit.edu>"
 
 # USER root
 # Ubuntu package installs
-RUN apt update 
-RUN apt install -y --no-install-recommends \
+RUN apt update && \
+    apt install -y --no-install-recommends \
     libfftw3-dev \
     git \
     wget && \
@@ -20,7 +20,7 @@ ENV LATEST_CONDA_SCRIPT "Miniconda3-py38_$MINICONDA_VERSION-Linux-x86_64.sh"
 RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/miniconda.sh && \
     bash ~/miniconda.sh -b -p $CONDA_DIR && \
     rm ~/miniconda.sh
-# RUN echo 'export PATH="~/miniconda/bin:$PATH"' >> ~/.bashrc 
+# RUN echo 'export PATH="/home/miniconda3/bin:$PATH"' >> ~/.bashrc 
 ENV PATH=$CONDA_DIR/bin:$PATH
 RUN conda update conda && \
     conda install conda-build
@@ -39,10 +39,6 @@ RUN conda env create -f pyks2.yml
 
 # Install pykilosort
 SHELL ["conda","run","-n","pyks2","/bin/bash","-c"]
-# RUN conda install --quiet --yes ipykernel && \
-#     python -m ipykernel install --user --name pyks2 --display-name "pyKilosort" && \
-RUN conda develop .
-
-
-
-
+RUN conda install --quiet --yes ipykernel && \
+    python -m ipykernel install --user --name pyks2 --display-name "pyKilosort" && \
+    conda develop .   

--- a/pykilosort/dockerfiles/Dockerfile
+++ b/pykilosort/dockerfiles/Dockerfile
@@ -30,7 +30,7 @@ RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile
 # make conda activate command available from /bin/bash --interactive shells
 RUN conda init bash
 
-# Install IBL port of pykilosort
+# Install python port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
 WORKDIR /src/pykilosort
 

--- a/pykilosort/dockerfiles/Dockerfile.testing
+++ b/pykilosort/dockerfiles/Dockerfile.testing
@@ -37,6 +37,8 @@ RUN conda init bash
 # Install python port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
 WORKDIR /src/pykilosort
+RUN git remote add MouseLand https://github.com/MouseLand/pykilosort.git && \
+    git fetch MouseLand && git checkout MouseLand/develop && git checkout -b develop
 
 # Create environment
 RUN conda env create -f pyks2.yml

--- a/pykilosort/dockerfiles/Dockerfile.testing
+++ b/pykilosort/dockerfiles/Dockerfile.testing
@@ -34,7 +34,7 @@ RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile
 # make conda activate command available from /bin/bash --interactive shells
 RUN conda init bash
 
-# Install IBL port of pykilosort
+# Install python port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
 WORKDIR /src/pykilosort
 

--- a/pykilosort/dockerfiles/Dockerfile.testing
+++ b/pykilosort/dockerfiles/Dockerfile.testing
@@ -1,0 +1,51 @@
+FROM nvidia/cuda:10.0-base-ubuntu18.04 
+
+LABEL maintainer="Vincent Prevosto <prevosto@mit.edu>"
+
+# Copy files for dev/tests
+COPY packages /srv/packages
+COPY test_files /home/test_files
+
+# USER root
+# Ubuntu package installs
+RUN apt update && \
+    apt install -y --no-install-recommends \
+    libfftw3-dev \
+    git \
+    wget && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install miniconda
+ENV MINICONDA_VERSION 4.12.0
+ENV CONDA_DIR /home/miniconda3
+ENV LATEST_CONDA_SCRIPT "Miniconda3-py38_$MINICONDA_VERSION-Linux-x86_64.sh"
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/$LATEST_CONDA_SCRIPT -O ~/miniconda.sh && \
+    bash ~/miniconda.sh -b -p $CONDA_DIR && \
+    rm ~/miniconda.sh
+# RUN echo 'export PATH="/home/miniconda3/bin:$PATH"' >> ~/.bashrc 
+ENV PATH=$CONDA_DIR/bin:$PATH
+RUN conda update conda && \
+    conda install conda-build
+
+# make conda activate command available from /bin/bash --login shells
+RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile 
+# make conda activate command available from /bin/bash --interactive shells
+RUN conda init bash
+
+# Install IBL port of pykilosort
+RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
+WORKDIR /src/pykilosort
+
+# Create environment
+RUN conda env create -f pyks2.yml
+
+# Install pykilosort
+SHELL ["conda","run","-n","pyks2","/bin/bash","-c"]
+RUN conda install --quiet --yes ipykernel && \
+    python -m ipykernel install --user --name pyks2 --display-name "pyKilosort" && \
+    pip install -U -r /srv/packages/testing_requirements.txt && \
+    conda develop .   
+
+RUN rm -rf /srv/packages

--- a/pykilosort/dockerfiles/Dockerfile.testing
+++ b/pykilosort/dockerfiles/Dockerfile.testing
@@ -37,6 +37,7 @@ RUN conda init bash
 # Install python port of pykilosort
 RUN git clone -b drift_test_stable https://github.com/kushbanga/pykilosort.git /src/pykilosort
 WORKDIR /src/pykilosort
+# Switch to MouseLand/develop branch - may revert to kushbanga/drift_test_stable in the future
 RUN git remote add MouseLand https://github.com/MouseLand/pykilosort.git && \
     git fetch MouseLand && git checkout MouseLand/develop && git checkout -b develop
 
@@ -51,3 +52,5 @@ RUN conda install --quiet --yes ipykernel && \
     conda develop .   
 
 RUN rm -rf /srv/packages
+
+WORKDIR /

--- a/pykilosort/push.sh
+++ b/pykilosort/push.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker push -t spikeinterface/pykilosort:0.1.0 .
+docker push --all-tags spikeinterface/pykilosort

--- a/pykilosort/push.sh
+++ b/pykilosort/push.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker push -t spikeinterface/pykilosort:0.1.0 .


### PR DESCRIPTION
Here's a first pass at a pyKilosort container for spikeinterface. It's not fully working yet but I wanted to get some feedback. 
First point, I followed the README instructions and used the `drift_test_stable` from `kushbanga`'s fork. It does look fairly far ahead of the original repo (IBL's fork also has a divergent `prod` branch with recent push). I assume this is fine.
Second, when testing pyKilosort within the container:
``` 
In [1]: from pathlib import Path
   ...: from pykilosort import run, add_default_handler, np1_probe, np2_probe

In [2]: data_path = Path('/data/Allen_Institute_NP1/continuous_1min.bin')
   ...: dir_path = Path('/data/Allen_Institute_NP1/pyKS_output')
   ...: add_default_handler(level='INFO')

In [3]: run(data_path, dir_path=dir_path, probe=np1_probe())
23:24:19.214 [I] utils:277            Loaded data with 385 channels, 1795324 samples
23:24:19.216 [I] utils:557            Starting step drift_correction.
23:24:19.216 [I] datashift2:618       pitch is 20.0 um
Extracting templates: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:03<00:00,  1.88it/s]
---------------------------------------------------------------------------
```
I get this error  

```
IndexError                                Traceback (most recent call last)
Input In [3], in <cell line: 1>()
----> 1 run(data_path, dir_path=dir_path, probe=np1_probe())

File /src/pykilosort/pykilosort/main.py:175, in run(dat_path, dir_path, output_dir, probe, stop_after, clear_context, **params)
    173     if "drift_correction" not in ctx.timer.keys():
    174         with ctx.time("drift_correction"):
--> 175             out = datashift2(ctx)
    176         ctx.save(**out)
    177 else:

File /src/pykilosort/pykilosort/datashift2.py:635, in datashift2(ctx)
    632     np.random.seed(params.seed)
    634 # determine prototypical timecourses by clustering of simple threshold crossings.
--> 635 wTEMP, wPCA = extractTemplatesfromSnippets(
    636     data_loader=ir.data_loader, probe=probe, params=params, Nbatch=Nbatch
    637 )
    639 # Extract all the spikes across the recording that are captured by the
    640 # generic templates. Very few real spikes are missed in this way.
    641 spikes = standalone_detector(
    642     wTEMP, wPCA, params.nPCs, yup, xup, Nbatch, ir.data_loader, probe, params
    643 )

File /src/pykilosort/pykilosort/learn.py:69, in extractTemplatesfromSnippets(data_loader, probe, params, Nbatch, nPCs)
     66     amax = cc[imax, np.arange(cc.shape[1])]
     67     for j in range(nPCs):
     68         # weighted average to get new cluster means
---> 69         wTEMP[:, j] = cp.dot(dd[:, imax == j], amax[imax == j].T)
     70     wTEMP = wTEMP / cp.sum(wTEMP ** 2, axis=0) ** 0.5  # unit normalize
     72 # the PCs are just the left singular vectors of the waveforms

File cupy/_core/core.pyx:1508, in cupy._core.core.ndarray.__setitem__()

File cupy/_core/_routines_indexing.pyx:51, in cupy._core._routines_indexing._ndarray_setitem()

File cupy/_core/_routines_indexing.pyx:967, in cupy._core._routines_indexing._scatter_op()

File cupy/_core/_routines_indexing.pyx:433, in cupy._core._routines_indexing._view_getitem()

IndexError: Index 0 is out of bounds for axis 1 with size 0
```
I'll debug this further this week, but if anyone (@oliche ?) has an idea of what's happening here, I'm happy to hear it. 
Thanks!

