### PR TITLE
Make do_correction optional for KS2.5 and KS3

### DIFF
--- a/kilosort_no_license/kilosort2_5-compiled/ks2_5_compiled.m
+++ b/kilosort_no_license/kilosort2_5-compiled/ks2_5_compiled.m
@@ -12,7 +12,13 @@ function ks2_5_compiled(fpath)
         rez = preprocessDataSub(ops);
 
         % NEW STEP TO DO DATA REGISTRATION
-        rez = datashift2(rez, 1); % last input is for shifting data
+        if isfield(ops, 'do_correction')
+            fprintf("Drift correction ENABLED")
+            do_correction = ops.do_correction;
+        else 
+            do_correction = 1;
+        end
+        rez = datashift2(rez, do_correction); % last input is for shifting data
 
         % ORDER OF BATCHES IS NOW RANDOM, controlled by random number generator
         iseed = 1;

--- a/kilosort_no_license/kilosort2_5-compiled/ks2_5_compiled.m
+++ b/kilosort_no_license/kilosort2_5-compiled/ks2_5_compiled.m
@@ -13,10 +13,15 @@ function ks2_5_compiled(fpath)
 
         % NEW STEP TO DO DATA REGISTRATION
         if isfield(ops, 'do_correction')
-            fprintf("Drift correction ENABLED")
             do_correction = ops.do_correction;
         else 
             do_correction = 1;
+        end
+
+        if do_correction
+            fprintf("Drift correction ENABLED\n");
+        else
+            fprintf("Drift correction DISABLED\n");
         end
         rez = datashift2(rez, do_correction); % last input is for shifting data
 

--- a/kilosort_no_license/kilosort3-compiled/ks3_compiled.m
+++ b/kilosort_no_license/kilosort3-compiled/ks3_compiled.m
@@ -12,7 +12,13 @@ function ks3_compiled(fpath)
         rez = preprocessDataSub(ops);
 
         % run data registration
-        rez = datashift2(rez, 1); % last input is for shifting data
+        if isfield(ops, 'do_correction')
+            fprintf("Drift correction ENABLED")
+            do_correction = ops.do_correction;
+        else 
+            do_correction = 1;
+        end
+        rez = datashift2(rez, do_correction); % last input is for shifting data
 
         [rez, st3, tF] = extract_spikes(rez);
 

--- a/kilosort_no_license/kilosort3-compiled/ks3_compiled.m
+++ b/kilosort_no_license/kilosort3-compiled/ks3_compiled.m
@@ -13,10 +13,15 @@ function ks3_compiled(fpath)
 
         % run data registration
         if isfield(ops, 'do_correction')
-            fprintf("Drift correction ENABLED")
             do_correction = ops.do_correction;
         else 
             do_correction = 1;
+        end
+
+        if do_correction
+            fprintf("Drift correction ENABLED\n");
+        else
+            fprintf("Drift correction DISABLED\n");
         end
         rez = datashift2(rez, do_correction); % last input is for shifting data
 


### PR DESCRIPTION
@chyumin related to this PR https://github.com/SpikeInterface/spikeinterface/pull/709: 
drift correction in KS2.5 and 3 can be turned off (still need to properly test it). When tested and merged, we would need to recompile the KS2.5 and KS3 images to reflect the changes