### PR TITLE
Remove cupy prints from pyks

### DIFF
--- a/pykilosort/Dockerfile
+++ b/pykilosort/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-base-ubuntu18.04 
+FROM nvidia/cuda:11.0.3-base-ubuntu18.04
 
 LABEL maintainer="Alessio Buccino <alessiop.buccino@gmail.com>"
 
@@ -30,8 +30,8 @@ RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> /root/.profile
 # make conda activate command available from /bin/bash --interactive shells
 RUN conda init bash
 
-# Install IBL python port of pykilosort
-RUN git clone -b 1.4.3 https://github.com/int-brain-lab/pykilosort.git /src/pykilosort
+# Install IBL python port of pykilosort - using #16 PR to remove prints from cupy
+RUN git clone -b remove_prints https://github.com/alejoe91/pykilosort.git /src/pykilosort
 WORKDIR /src/pykilosort
 
 # modify env file so that env extends on base

--- a/pykilosort/build.sh
+++ b/pykilosort/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/pykilosort-base:latest -t spikeinterface/pykilosort-base:1.4.3 .
+docker build -t spikeinterface/pykilosort-base:latest -t spikeinterface/pykilosort-base:1.4.3.1 .


### PR DESCRIPTION
Temporary fix to avoid these annoying prints:
https://github.com/int-brain-lab/pykilosort/pull/16/files#diff-893476655f804612bc42302220d29a5ce7404d284a3c5d0c0127bff62b0f4821L17-L19