### PR TITLE
Upgrade MS5 image to v0.5.3

### DIFF
--- a/mountainsort5/Dockerfile
+++ b/mountainsort5/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.8
+FROM python:3.10
 
 # downgrade pip version to avoid dependency issues during installations
-RUN pip install --no-input pip==21.2.4
+RUN pip install --upgrade pip
 
 RUN pip install numpy
 
-RUN pip install mountainsort5==0.3.0
+RUN pip install mountainsort5==0.5.3

--- a/mountainsort5/build.sh
+++ b/mountainsort5/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/mountainsort5-base:latest -t spikeinterface/mountainsort5-base:0.3.0 .
+docker build -t spikeinterface/mountainsort5-base:latest -t spikeinterface/mountainsort5-base:0.5.3 .


### PR DESCRIPTION
Updating from v0.3.0 to v0.5.3 (otherwise incompatible with SpikeInterface main due to new utils functions)

Also bumped up Python3.8 to 3.10