### PR TITLE
update to herdingspikes 0.4

### DIFF
--- a/herdingspikes/Dockerfile
+++ b/herdingspikes/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.8
+FROM python:3.12
 
-RUN pip install numpy==1.20.0
+RUN pip install numpy
+RUN pip install cython
 
-RUN pip install herdingspikes==0.3.99
+RUN pip install herdingspikes==0.4.1

--- a/herdingspikes/build.sh
+++ b/herdingspikes/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t spikeinterface/herdingspikes-base:latest -t spikeinterface/herdingspikes-base:0.3.99 .
+docker build -t spikeinterface/herdingspikes-base:latest -t spikeinterface/herdingspikes-base:0.4.1 .


### PR DESCRIPTION
This should enable running HS with SpikeInterface.
Note SI is a dependency (although only for practical reasons, not really required) of HS (when pip installed), is this a problem?